### PR TITLE
Fix docker command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,4 @@ if [ -n "${INPUT_PUBLIC_HOST}" ]; then
 	args+=(-public-host "${INPUT_PUBLIC_HOST}")
 fi
 
-exec docker run -d --port 4443:4443 "fsouza/fake-gcs-version:${INPUT_VERSION}" "${args[@]}"
+exec docker run -d -p 4443:4443 "fsouza/fake-gcs-version:${INPUT_VERSION}" "${args[@]}"


### PR DESCRIPTION
It seems that `--port` isn't supported.

```
/usr/bin/docker run --name d35b0f5a33d8a74ff2ad1b579a31655d39_476277 --label 3888d3 --workdir /github/workspace --rm -e INPUT_VERSION -e INPUT_BACKEND -e INPUT_DATA -e INPUT_PUBLIC-HOST -e INPUT_EXTERNAL-URL -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/redacted-repo-name/redacted-repo-name":"/github/workspace" 3888d3:5b0f5a33d8a74ff2ad1b579a31655d39
unknown flag: --port
```